### PR TITLE
feat/FFENT-11161- Align Upscale GA in spec, changelog, and home

### DIFF
--- a/src/pages/getting-started/changelog/index.md
+++ b/src/pages/getting-started/changelog/index.md
@@ -38,6 +38,67 @@ twitter:
 [//]: # (TODO: Update with latest prod details, elaborate on API descriptions)
 # Changelog
 
+## April 24, 2026
+
+### Upscale API: Beta to GA (Breaking Change)
+
+During the beta period, the `/v3/images/upscale` endpoint was named and documented as the "creative upsampler"; however the underlying model being called was always the **precise upsampler**. This GA release corrects that naming inconsistency. The service behavior is unchanged; only the names are being aligned to reflect reality.
+
+### ⚠️ Breaking Changes
+
+#### 1. `creative_upsampler_v1` header value rejected
+
+Passing `creative_upsampler_v1` in the `x-model-version` header now returns a **422 Unprocessable Entity**:
+
+```json
+{
+  "error_code": "validation_error",
+  "message": "Invalid x-model-version: creative_upsampler_v1. Only 'precise_upsampler_v1' is supported."
+}
+```
+
+**Action required:** Update or remove the `x-model-version` header. The new default is `precise_upsampler_v1`.
+
+```http
+x-model-version: precise_upsampler_v1
+```
+
+#### 2. Schema and operation identifiers renamed
+
+All `Creative*` upsampler identifiers have been renamed to `Precise*` to reflect the correct underlying model. If you are using a generated SDK or referencing schema `$ref` values directly, update accordingly.
+
+| Old name (beta) | New name (GA) |
+| --- | --- |
+| `creativeUpsamplerV3Async` | `preciseUpsamplerV3Async` |
+| `CreativeUpsamplerRequestV3` | `PreciseUpsamplerRequestV3` |
+| `CreativeUpscaleAcceptResponseV3` | `PreciseUpscaleAcceptResponseV3` |
+| `CreativeUpscaleTaskLink` | `PreciseUpscaleTaskLink` |
+| `CreativeUpsamplerResponse` | `PreciseUpsamplerResponse` |
+
+> **Note:** The request body shape and response structure are **unchanged**. This is a rename only; no fields have been added, removed, or modified.
+
+### Summary of all spec changes
+
+| Area | Before (beta) | After (GA) |
+| --- | --- | --- |
+| `x-model-version` accepted values | `creative_upsampler_v1` | `precise_upsampler_v1` |
+| `x-model-version` default | `creative_upsampler_v1` | `precise_upsampler_v1` |
+| Invalid model version response | Undefined behaviour | `422` with `validation_error` |
+| `operationId` | `creativeUpsamplerV3Async` | `preciseUpsamplerV3Async` |
+| Request schema | `CreativeUpsamplerRequestV3` | `PreciseUpsamplerRequestV3` |
+| Accept response schema | `CreativeUpscaleAcceptResponseV3` | `PreciseUpscaleAcceptResponseV3` |
+| Task link schema | `CreativeUpscaleTaskLink` | `PreciseUpscaleTaskLink` |
+| Result schema | `CreativeUpsamplerResponse` | `PreciseUpsamplerResponse` |
+| Endpoint summary | `Upscale image (beta)` | `Upscale image` |
+| `Upscale` tag description | `...creative upsampler (beta)` | `...precise upsampler` |
+
+### Deprecation timeline
+
+| Date | Event |
+| --- | --- |
+| Prior to 2026-04-24 | Beta: `creative_upsampler_v1` available; underlying model was always the precise upsampler |
+| **2026-04-24** | **GA: `creative_upsampler_v1` removed; `precise_upsampler_v1` is the only supported value; all schema identifiers corrected** |
+
 ## March 25, 2026
 
 **API updates**

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -56,9 +56,9 @@ Blend product shots and objects into generated scenes with complementing tones, 
 
 <DiscoverBlock slots="link, text"/>
 
-[Upscale API (beta)](#upscale-api-beta)
+[Upscale API](#upscale-api)
 
-Enhance image resolution and quality at scale with the Upscale API (beta).
+Enhance image resolution and quality at scale with the Upscale API.
 
 ## Custom Models API
 
@@ -121,7 +121,7 @@ Use Adaptive Composite to:
 
 To get started, see the [Object Composite API Feature Guide](guides/how-tos/object-composite/index.md).
 
-## Upscale API (beta)
+## Upscale API
 
 Enhance image resolution and quality quickly and effortlessly, without pixelation or retakes.
 

--- a/static/firefly-api.json
+++ b/static/firefly-api.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "3.0.0",
     "title": "Firefly API",
-    "description": "REST API for Adobe Firefly services including image generation, image alteration, image upscaling (beta), video generation, and other related services."
+    "description": "REST API for Adobe Firefly services including image generation, image alteration, image upscaling, video generation, and other related services."
   },
   "servers": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Upscale",
-      "description": "Image upscaling with the creative upsampler (beta)."
+      "description": "Image upscaling with the precise upsampler."
     },
     {
         "name": "Manage jobs",
@@ -1741,20 +1741,23 @@
     },
     "/v3/images/upscale": {
       "post": {
-        "operationId": "creativeUpsamplerV3Async",
-        "summary": "Upscale image (beta)",
-        "description": "Upscales an image asynchronously using the creative upsampler (beta). Provide the input image via an upload ID from the storage API or a presigned URL. The response includes links to check status and retrieve the result. Poll the status URL until the job completes, then fetch the result for the upscaled image(s).",
+        "operationId": "preciseUpsamplerV3Async",
+        "summary": "Upscale image",
+        "description": "Upscales an image asynchronously using the precise upsampler. Provide the input image via an upload ID from the storage API or a presigned URL. The response includes links to check status and retrieve the result. Poll the status URL until the job completes, then fetch the result for the upscaled image(s).",
         "tags": ["Upscale"],
         "parameters": [
           {
             "name": "x-model-version",
             "in": "header",
             "required": false,
-            "description": "Model version for the upscale operation. Use creative_upsampler_v1.",
+            "description": "Model version for the upscale operation. Only `precise_upsampler_v1` is supported. Passing `creative_upsampler_v1` will return a 422 validation error.",
             "schema": {
               "type": "string",
-              "default": "creative_upsampler_v1",
-              "example": "creative_upsampler_v1"
+              "enum": [
+                "precise_upsampler_v1"
+              ],
+              "default": "precise_upsampler_v1",
+              "example": "precise_upsampler_v1"
             }
           }
         ],
@@ -1763,7 +1766,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreativeUpsamplerRequestV3"
+                "$ref": "#/components/schemas/PreciseUpsamplerRequestV3"
               },
               "example": {
                 "image": {
@@ -1783,7 +1786,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreativeUpscaleAcceptResponseV3"
+                  "$ref": "#/components/schemas/PreciseUpscaleAcceptResponseV3"
                 },
                 "example": {
                   "links": {
@@ -1844,6 +1847,15 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ValidationErrorResponse"
+                },
+                "examples": {
+                  "invalid_model_version": {
+                    "summary": "Invalid x-model-version value",
+                    "value": {
+                      "error_code": "validation_error",
+                      "message": "Invalid x-model-version: creative_upsampler_v1. Only 'precise_upsampler_v1' is supported."
+                    }
+                  }
                 }
               }
             }
@@ -2186,7 +2198,7 @@
     "/v2/storage/image": {
       "post": {
         "summary": "Upload image",
-        "description": "Upload source image or mask for image-to-image operations, such as fill, expand, or upscale (beta). This API returns an identifier that is used to refer to uploaded content. The uploaded assets will be valid for 7 days from the date you upload them.",
+        "description": "Upload source image or mask for image-to-image operations, such as fill, expand, or upscale. This API returns an identifier that is used to refer to uploaded content. The uploaded assets will be valid for 7 days from the date you upload them.",
         "operationId": "storageImageV2",
         "tags": ["Common Operations"],
         "requestBody": {
@@ -3071,7 +3083,7 @@
                 "$ref": "#/components/schemas/JobResult"
               },
               {
-                "$ref": "#/components/schemas/CreativeUpsamplerResponse"
+                "$ref": "#/components/schemas/PreciseUpsamplerResponse"
               }
             ]
           }
@@ -3254,7 +3266,7 @@
         "properties": {
           "source": {
             "$ref": "#/components/schemas/PublicBinaryInputV3",
-            "description": "Source image that Firefly expands, fills, uses to generate similar images, or upscales (beta)."
+            "description": "Source image that Firefly expands, fills, uses to generate similar images, or upscales."
           }
         },
         "required": [
@@ -3263,17 +3275,17 @@
         "title": "BaseInputImageV3",
         "type": "object"
       },
-      "CreativeUpscaleAcceptResponseV3": {
+      "PreciseUpscaleAcceptResponseV3": {
         "type": "object",
-        "title": "CreativeUpscaleAcceptResponseV3",
-        "description": "Response for async upscale requests (beta). Use links.result.href to poll for status and links.cancel.href to cancel.",
+        "title": "PreciseUpscaleAcceptResponseV3",
+        "description": "Response for async upscale requests. Use links.result.href to poll for status and links.cancel.href to cancel.",
         "required": ["links"],
         "properties": {
           "links": {
             "type": "object",
             "description": "Links to cancel and to fetch the job status or result.",
             "additionalProperties": {
-              "$ref": "#/components/schemas/CreativeUpscaleTaskLink"
+              "$ref": "#/components/schemas/PreciseUpscaleTaskLink"
             }
           },
           "progress": {
@@ -3282,9 +3294,9 @@
           }
         }
       },
-      "CreativeUpscaleTaskLink": {
+      "PreciseUpscaleTaskLink": {
         "type": "object",
-        "title": "CreativeUpscaleTaskLink",
+        "title": "PreciseUpscaleTaskLink",
         "required": ["href"],
         "properties": {
           "href": {
@@ -3293,10 +3305,10 @@
           }
         }
       },
-      "CreativeUpsamplerRequestV3": {
+      "PreciseUpsamplerRequestV3": {
         "type": "object",
-        "title": "CreativeUpsamplerRequestV3",
-        "description": "Request body for upscaling an image (beta). Provide the input image via uploadId from storage or a presigned URL. Seeds are required for reproducible results.",
+        "title": "PreciseUpsamplerRequestV3",
+        "description": "Request body for upscaling an image. Provide the input image via uploadId from storage or a presigned URL. Seeds are required for reproducible results.",
         "required": ["image", "seeds"],
         "properties": {
           "image": {
@@ -3323,10 +3335,10 @@
           }
         }
       },
-      "CreativeUpsamplerResponse": {
+      "PreciseUpsamplerResponse": {
         "type": "object",
-        "title": "CreativeUpsamplerResponse",
-        "description": "Upscale result (beta). Each item in outputs is a storage reference for an upscaled image.",
+        "title": "PreciseUpsamplerResponse",
+        "description": "Upscale result. Each item in outputs is a storage reference for an upscaled image.",
         "required": ["outputs", "version"],
         "properties": {
           "outputs": {


### PR DESCRIPTION
# Summary

Aligns the Firefly API reference and developer docs with the Upscale API GA release: precise upsampler naming, OpenAPI identifiers, and removal of consumer-facing “beta” wording. Adds a changelog entry documenting the Beta-to-GA migration and breaking identifier changes for integrators.

# Changes

## `static/firefly-api.json`

* Updates API `info` description, Upscale tag text, and related strings to drop beta and describe the precise upsampler.
* Renames upscale `operationId` to `preciseUpsamplerV3Async`, summary to “Upscale image”, and request/response schema refs to PreciseUpsampler/PreciseUpscale types.
* Restricts `x-model-version` to `precise_upsampler_v1` with documentation and a 422 example for legacy `creative_upsampler_v1`.
* Adjusts job result union, storage upload description, and `BaseInputImageV3` source description for GA wording.

## `src/pages/getting-started/changelog/index.md`

* Documents the Upscale API Beta-to-GA release (April 24, 2026), naming alignment, schema renames, and migration guidance for developers.

## `src/pages/index.md`

* Removes “(beta)” from the Upscale DiscoverBlock link, teaser, and section heading; updates the in-page anchor to `#upscale-api`.

# Context

## Jira

[FFENT-11161](https://jira.corp.adobe.com/browse/FFENT-11161)
