### PR TITLE
docs/FFENT-9944- Link video sizes to usage-notes aspect ratios

### DIFF
--- a/static/firefly-api.json
+++ b/static/firefly-api.json
@@ -4473,7 +4473,7 @@
             ]
           },
           "sizes": {
-            "description": "The dimensions of the generated video.",
+            "description": "The dimensions of the generated video. Consult the [supported aspect ratios in the usage notes](https://developer.adobe.com/firefly-services/docs/firefly-api/getting-started/usage-notes/#supported-aspect-ratios) for allowed values.",
             "items": {
               "$ref": "#/components/schemas/ClinetoSize"
             },


### PR DESCRIPTION
# Summary

Adds a cross-link from the OpenAPI description for generated-video `sizes` to the usage notes section that documents supported aspect ratios, so API consumers can find allowed values without leaving the product docs path.

# Changes

## `static/firefly-api.json`

* Expands the `sizes` property description (generated video schema) with a Markdown link to [Supported aspect ratios](https://developer.adobe.com/firefly-services/docs/firefly-api/getting-started/usage-notes/#supported-aspect-ratios) in the usage notes.

# Context

## Jira

[FFENT-9944](https://jira.corp.adobe.com/browse/FFENT-9944)
