### PR TITLE
docs/FFENT-10638- Polish Image5 reference blob OpenAPI copy

### DIFF
--- a/static/firefly-api.json
+++ b/static/firefly-api.json
@@ -3915,7 +3915,7 @@
           "url": {
             "type": "string",
             "title": "URL",
-            "description": "URL of the reference image. Presigned URLs are not supported for Image5; images must be uploaded to Adobe storage."
+            "description": "URL of the reference image."
           }
         }
       },

--- a/static/firefly-api.json
+++ b/static/firefly-api.json
@@ -300,7 +300,7 @@
       "post": {
         "operationId": "firefly_image_v5_generate_async_v4",
         "summary": "Generate images with Image5",
-        "description": "Generate images asynchronously using Firefly's Image5 model. When referenceBlobs is not empty, omit aspectRatio or set it to auto.",
+        "description": "Generate images asynchronously using Firefly's Image5 model. When <code>referenceBlobs</code> is included in the request, omit <code>aspectRatio</code> or set it to <code>auto</code>.",
         "tags": ["Common Operations"],
         "parameters": [
           {
@@ -3819,7 +3819,7 @@
           },
           "aspectRatio": {
             "$ref": "#/components/schemas/AspectRatio",
-            "description": "`aspectRatio`: The aspect ratio of the requested generations. This controls the size of the generated image. When <code>referenceBlobs</code> is not empty, this property should be omitted or set to <code>auto</code>."
+            "description": "The aspect ratio of the requested generations. This controls the size of the generated image. When <code>referenceBlobs</code> is included in the request, this property should be omitted or set to <code>auto</code>."
        
           },
           "resolutionLevel": {
@@ -3849,7 +3849,7 @@
               "$ref": "#/components/schemas/ReferenceBlobV3"
             },
             "title": "Reference blobs",
-            "description": "List of reference blobs that will be used as additional input for the generation process. Only one reference image is supported. When this array is not empty, aspectRatio must be omitted or set to auto. [Pre-signed URLs can be used from supported domains](https://developer.adobe.com/firefly-services/docs/firefly-api/getting-started/usage-notes/#image-api-usage).",
+            "description": "List of reference blobs that will be used as additional input for the generation process. Only one reference image is supported. When this array is not empty, <code>aspectRatio</code> must be omitted or set to <code>auto</code>. [Pre-signed URLs can be used from supported domains](https://developer.adobe.com/firefly-services/docs/firefly-api/getting-started/usage-notes/#image-api-usage).",
             "default": [],
             "maxItems": 1
           },
@@ -3888,7 +3888,7 @@
       "ReferenceBlobV3": {
         "type": "object",
         "title": "ReferenceBlobV3",
-        "description": "Reference blob for V3 API. Style Guide compliant: The 'source' property specifies the input location, and other properties like 'usage' are peers of 'source'.",
+        "description": "Reference blob for V3 API. Style Guide compliant: The <code>source</code> property specifies the input location, and other properties like <code>usage</code> are peers of <code>source</code>.",
         "required": ["source"],
         "properties": {
           "source": {


### PR DESCRIPTION
# Summary

Polishes Firefly Image5 async generate and related request-schema copy in
the OpenAPI spec: consistent phrasing for `referenceBlobs` and
`aspectRatio`, HTML `<code>` markup for field names, and a shorter
`ReferenceBlobSourceV3` URL property description.

# Changes

## `static/firefly-api.json`

* Async Image5 generate operation description now uses `<code>` for
  `referenceBlobs` and `aspectRatio` and says when the latter should be
  omitted or set to `auto`.
* `ImageGenerateRequestV3` `aspectRatio` and `referenceBlobs` descriptions
  align on “included in the request” / `<code>aspectRatio</code>` wording;
  redundant `` `aspectRatio`: `` prefix removed from `aspectRatio`.
* `ReferenceBlobV3` schema description uses `<code>` for `source` and
  `usage` instead of straight quotes.
* `ReferenceBlobSourceV3` `url` description shortened to a single sentence
  (presigned/Image5 storage caveat removed).

# Context

## Jira

[FFENT-10638](https://jira.corp.adobe.com/browse/FFENT-10638)
