### PR TITLE
fix/FFENT-11843- Align resolutionLevel enum for Generate Image v3

### DIFF
--- a/static/firefly-api.json
+++ b/static/firefly-api.json
@@ -328,7 +328,7 @@
                   "value": {
                     "prompt": "A futuristic city glowing at night, with neon lights and flying cars",
                     "aspectRatio": "auto",
-                    "resolutionLevel": "2MP",
+                    "resolutionLevel": "2.4MP",
                     "modelId": "firefly_image",
                     "numVariations": 1,
                     "seeds": [42345],
@@ -361,7 +361,7 @@
                   "summary": "Image-to-Image instruct edit",
                   "value": {
                     "prompt": "Add warm sunset lighting and enhance the reflection on the water",
-                    "resolutionLevel": "auto",
+                    "resolutionLevel": "2.4MP",
                     "modelId": "firefly_image",
                     "numVariations": 1,
                     "referenceBlobs": [
@@ -3826,8 +3826,8 @@
             "type": "string",
             "title": "Resolution level",
             "description": "The resolution level.",
-            "enum": ["1MP", "2MP", "4MP", "auto"],
-            "default": "auto"
+            "enum": ["1MP", "2.4MP", "4MP"],
+            "default": "2.4MP"
           },
           "modelId": {
             "$ref": "#/components/schemas/FireflyModelId",


### PR DESCRIPTION
# Summary

Updates the Generate Image v3 request schema so `resolutionLevel` matches the supported values: `1MP`, `2.4MP`, and `4MP`, with default `2.4MP`. Removes obsolete `2MP` and `auto` from the enum and refreshes request examples accordingly.

# Changes

## `static/firefly-api.json`
* Set `resolutionLevel` enum to `["1MP", "2.4MP", "4MP"]` and default to `2.4MP`.
* Update generate-async request examples to use valid `resolutionLevel` values (`2.4MP` where text-to-image and image-to-image examples previously used `2MP` or `auto`).

# Context

## Jira
[FFENT-11843](https://jira.corp.adobe.com/browse/FFENT-11843)


Made with [Cursor](https://cursor.com)