### PR TITLE
feat/FFENT-12743- Add Beta Support button to site header

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -20,8 +20,9 @@
     - [API Reference](/api/index.md)
 
 - buttons:
-    - [Support](https://airtable.com/appu5RTWgdM95jynx/pagyuT1qspNJcPU2E/form)
     - [Console](https://developer.adobe.com/console/) consoleId
+    - [Support](https://airtable.com/appu5RTWgdM95jynx/pagyuT1qspNJcPU2E/form) API service support.
+    - [Beta Support](https://airtable.com/appO8JiYWk279LUwc/pag6aTXGt6qWqlvjr/form) Public beta services API support.
     
 - subPages:
     - [Quickstart](/guides/index.md)


### PR DESCRIPTION
# Summary
Adds a Beta Support header button for public beta API services and clarifies existing Support link labels in the site navigation config.

# Changes

## `src/pages/config.md`
* Reorder header buttons so Console appears before Support links.
* Add descriptive labels for the existing Support button (API service support).
* Add a new Beta Support button linking to the public beta services Airtable form.

# Context

## Jira
[FFENT-12743](https://jira.corp.adobe.com/browse/FFENT-12743)

Made with [Cursor](https://cursor.com)